### PR TITLE
[Fix] Autoscale for libp2p limiter

### DIFF
--- a/p2p/p2p_service.go
+++ b/p2p/p2p_service.go
@@ -99,7 +99,7 @@ func getPrivKey(broker *common.MessageBroker) libp2pcrypto.PrivKey {
 }
 
 func createLibp2pNode(privKey libp2pcrypto.PrivKey, ctx context.Context) (node host.Host, err error) {
-	limiter := rcmgr.NewFixedLimiter(rcmgr.InfiniteLimits)
+	limiter := rcmgr.NewFixedLimiter(rcmgr.DefaultLimits.AutoScale())
 	rcm, err := rcmgr.NewResourceManager(limiter)
 	if err != nil {
 		return
@@ -163,6 +163,7 @@ func (p *P2PService) ForwardP2PToEventBus(proto string) {
 	p.p2pNode.SetStreamHandler(protocol.ID(proto), func(s network.Stream) {
 		buf, err := io.ReadAll(s)
 		if err != nil {
+			log.WithError(err).Error("stream_read")
 			if e := s.Reset(); e != nil {
 				log.WithError(e).Error("could not reset stream")
 			}

--- a/tendermint/abci.go
+++ b/tendermint/abci.go
@@ -198,10 +198,10 @@ func (abci *ABCI) EndBlock(req abcitypes.RequestEndBlock) abcitypes.ResponseEndB
 
 	buffer := abci.broker.ChainMethods().KeyBuffer()
 	var maxKeyInit int
-	if buffer > 250 {
-		maxKeyInit = buffer / 250
+	if buffer > 500 {
+		maxKeyInit = buffer / 500
 	} else {
-		maxKeyInit = buffer
+		maxKeyInit = 100
 	}
 
 	if int(abci.state.LastCreatedIndex)-int(abci.state.LastUnassignedIndex) < buffer {

--- a/tendermint/abci_handlers.go
+++ b/tendermint/abci_handlers.go
@@ -138,8 +138,7 @@ func (abci *ABCI) ValidateAndUpdateAndTagBFTTx(bftTx []byte, msgType byte, sende
 	if err != nil {
 		return false, &tags, fmt.Errorf("could not get current epoch with err: %v", err)
 	}
-	t := int(currEpochInfo.T.Int64())
-	n := int(currEpochInfo.N.Int64())
+	threshold := int(currEpochInfo.K.Int64())
 	switch msgType {
 	case byte(1): // Assignment tx
 
@@ -284,9 +283,8 @@ func (abci *ABCI) ValidateAndUpdateAndTagBFTTx(bftTx []byte, msgType byte, sende
 				}
 			}
 
-			if len(abci.state.KeygenDecisions[key].Nodes) == n-t {
-				log.Infof("abci.decisions_threshold=%d", n-t)
-
+			log.Infof("abci.decisions: current=%d, threshold=%d", len(abci.state.KeygenDecisions[key].Nodes), threshold)
+			if len(abci.state.KeygenDecisions[key].Nodes) == threshold {
 				log.Infof("Generated PK: index=%d, publickey=%s%s", keyIndex.Int64(), m.PublicKey.X.Text(16), m.PublicKey.Y.Text(16))
 				err = abci.broker.DBMethods().StorePublicKeyToIndex(m.PublicKey, keyIndex)
 				if err != nil {

--- a/tendermint/core_service.go
+++ b/tendermint/core_service.go
@@ -204,6 +204,8 @@ func getTendermintConfig(buildPath string, peers string) *cfg.Config {
 
 	defaultConfig.Consensus.CreateEmptyBlocks = false
 
+	defaultConfig.Mempool.Size = 10000
+
 	defaultConfig.BaseConfig.DBBackend = "goleveldb"
 	defaultConfig.FastSyncMode = false
 	// defaultConfig.RPC.ListenAddress = fmt.Sprintf("tcp://%s:26657", config.GlobalConfig.IPAddress)


### PR DESCRIPTION
- Using autoscale for limiter config in libp2p
- Reduced % of keygen start
- Increased mempool size