### PR TITLE
Fix ReadyCounter RC will never get higher than 1

### DIFF
--- a/keygen/message_handlers/acss/echo_handler.go
+++ b/keygen/message_handlers/acss/echo_handler.go
@@ -125,7 +125,7 @@ func (m EchoMessage) Process(sender common.KeygenNodeDetails, self common.DkgPar
 		go self.Broadcast(*readyMsg)
 	}
 
-	if c.RC >= f+1 && !c.ReadySent && c.EC >= f+1 {
+	if len(keygen.ReadyStore) >= f+1 && !c.ReadySent && c.EC >= f+1 {
 		// Broadcast ready message
 		readyMsg, err := NewReadyMessage(m.RoundID, m.Share, m.Hash, m.Curve)
 		if err != nil {

--- a/keygen/message_handlers/acss/ready_handler.go
+++ b/keygen/message_handlers/acss/ready_handler.go
@@ -98,9 +98,9 @@ func (m ReadyMessage) Process(sender common.KeygenNodeDetails, self common.DkgPa
 	// increment the ready messages received
 	c.RC = c.RC + 1
 	n, k, f := self.Params()
-	log.Debugf("cid=%v,ready_count=%d, threshold=%d, node=%d", cid, c.RC, k, self.ID())
+	log.Debugf("cid=%v,ready_count=%d, threshold=%d, node=%d", cid, len(keygen.ReadyStore), k, self.ID())
 
-	if c.RC >= f+1 && !c.ReadySent && c.EC >= f+1 {
+	if len(keygen.ReadyStore) >= f+1 && !c.ReadySent && c.EC >= f+1 {
 		// Broadcast ready message
 		readyMsg, err := NewReadyMessage(m.RoundID, m.Share, m.Hash, m.Curve)
 		if err != nil {

--- a/keygen/message_handlers/keyset/echo_handler.go
+++ b/keygen/message_handlers/keyset/echo_handler.go
@@ -115,7 +115,7 @@ func (m EchoMessage) Process(sender common.KeygenNodeDetails, self common.DkgPar
 		go self.Broadcast(*readyMsg)
 	}
 
-	if c.RC >= f+1 && !c.ReadySent && c.EC >= f+1 {
+	if len(keygen.ReadyStore) >= f+1 && !c.ReadySent && c.EC >= f+1 {
 		// Broadcast ready message
 		readyMsg, err := NewReadyMessage(m.RoundID, m.Share, m.Hash, m.Curve)
 		if err != nil {

--- a/keygen/message_handlers/keyset/ready_handler.go
+++ b/keygen/message_handlers/keyset/ready_handler.go
@@ -98,9 +98,9 @@ func (m ReadyMessage) Process(sender common.KeygenNodeDetails, self common.DkgPa
 	// increment the ready messages received
 	c.RC = c.RC + 1
 	n, _, f := self.Params()
-	log.Debugf("cid=%v,ready_count=%d, threshold=%d, node=%d", cid, c.RC, f+1, self.ID())
+	log.Debugf("cid=%v,ready_count=%d, threshold=%d, node=%d", cid, len(keygen.ReadyStore), f+1, self.ID())
 
-	if c.RC >= f+1 && !c.ReadySent && c.EC >= f+1 {
+	if len(keygen.ReadyStore) >= f+1 && !c.ReadySent && c.EC >= f+1 {
 		// Broadcast ready message
 		readyMsg, err := NewReadyMessage(m.RoundID, m.Share, m.Hash, m.Curve)
 		if err != nil {


### PR DESCRIPTION
This PR fixes that ```c.RC``` in ```echo_handler``` and ```ready_handler``` will never get higher than 1 by changing it to ```len(keygen.ReadyStore)```.